### PR TITLE
Update sha256sum & fixed patch

### DIFF
--- a/python-dm-tree/.SRCINFO
+++ b/python-dm-tree/.SRCINFO
@@ -14,7 +14,10 @@ pkgbase = python-dm-tree
 	makedepends = git
 	depends = python
 	depends = python-six
+	depends = abseil-cpp
 	source = python-dm-tree-0.1.8.tar.gz::https://pypi.org/packages/source/d/dm-tree/dm-tree-0.1.8.tar.gz
+	source = CMakeLists.txt.patch
 	sha256sums = 0fcaabbb14e7980377439e7140bd05552739ca5e515ecb3119f234acee4b9430
+	sha256sums = 84c9cbd52b3852af2e97dc6261c0114c78d40bc3deeb6b7638dd3864df1a9f72
 
 pkgname = python-dm-tree

--- a/python-dm-tree/CMakeLists.txt.patch
+++ b/python-dm-tree/CMakeLists.txt.patch
@@ -1,4 +1,3 @@
-diff -ur dm-tree-0.1.8.orig/tree/CMakeLists.txt dm-tree-0.1.8/tree/CMakeLists.txt
 --- dm-tree-0.1.8.orig/tree/CMakeLists.txt	2022-12-18 12:35:42.000000000 +0300
 +++ dm-tree-0.1.8/tree/CMakeLists.txt	2023-06-15 16:56:39.291503035 +0300
 @@ -11,8 +11,8 @@
@@ -36,7 +35,7 @@ diff -ur dm-tree-0.1.8.orig/tree/CMakeLists.txt dm-tree-0.1.8/tree/CMakeLists.tx
  endif()
  
  if(APPLE)
-@@ -67,54 +62,19 @@
+@@ -67,51 +62,19 @@
  # Needed to disable Abseil tests.
  set (BUILD_TESTING OFF)
  
@@ -75,7 +74,7 @@ diff -ur dm-tree-0.1.8.orig/tree/CMakeLists.txt dm-tree-0.1.8/tree/CMakeLists.tx
  # Define pybind11 tree module.
  pybind11_add_module(_tree tree.h tree.cc)
 -add_dependencies(_tree abseil-cpp)
--
+ 
 -if (WIN32 OR MSVC)
 -    set(ABSEIL_LIB_PREF "absl")
 -    set(LIB_SUFF "lib")
@@ -89,11 +88,9 @@ diff -ur dm-tree-0.1.8.orig/tree/CMakeLists.txt dm-tree-0.1.8/tree/CMakeLists.tx
 -set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)
  foreach(ABSEIL_LIB IN LISTS ABSEIL_LIBS)
 -  target_link_libraries(_tree PRIVATE
--      "${abseil_install_dir}/lib/python-dm-tree/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
+-      "${abseil_install_dir}/lib/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
 +  target_link_libraries(_tree PRIVATE "absl::${ABSEIL_LIB}")
  endforeach()
  
  # Make the module private to tree package.
- set_target_properties(_tree PROPERTIES OUTPUT_NAME tree/_tree)
--
--
+

--- a/python-dm-tree/CMakeLists.txt.patch
+++ b/python-dm-tree/CMakeLists.txt.patch
@@ -1,0 +1,99 @@
+diff -ur dm-tree-0.1.8.orig/tree/CMakeLists.txt dm-tree-0.1.8/tree/CMakeLists.txt
+--- dm-tree-0.1.8.orig/tree/CMakeLists.txt	2022-12-18 12:35:42.000000000 +0300
++++ dm-tree-0.1.8/tree/CMakeLists.txt	2023-06-15 16:56:39.291503035 +0300
+@@ -11,8 +11,8 @@
+     "Python found ${Python3_VERSION} < 3.6.0")
+ endif()
+ 
+-# Use C++14 standard.
+-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ version selection")
++# Use C++17 standard.
++set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ version selection")
+ 
+ # Position-independent code is needed for Python extension modules.
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+@@ -27,17 +27,12 @@
+ message("PROJECT_BINARY_DIR is: ${PROJECT_BINARY_DIR}")
+ 
+ if (NOT (WIN32 OR MSVC))
+-  if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+-    # Basic build for debugging (default).
+-    # -Og enables optimizations that do not interfere with debugging.
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Og")
+-  endif()
+-
+-  if(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+-    # Optimized release build: turn off debug runtime checks
+-    # and turn on highest speed optimizations.
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNDEBUG -O3")
+-  endif()
++  # Basic build for debugging (default).
++  # -Og enables optimizations that do not interfere with debugging.
++  set(CMAKE_CXX_FLAGS_DEBUG "-g -Og")
++  # Optimized release build: turn off debug runtime checks
++  # and turn on highest speed optimizations.
++  set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+ endif()
+ 
+ if(APPLE)
+@@ -67,54 +62,19 @@
+ # Needed to disable Abseil tests.
+ set (BUILD_TESTING OFF)
+ 
+-# Include abseil-cpp.
+-set(ABSEIL_VER 20210324.2)
+-include(ExternalProject)
+-set(ABSEIL_CMAKE_ARGS
+-    "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/abseil-cpp"
+-    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+-    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+-    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+-    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+-    "-DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}"
+-    "-DLIBRARY_OUTPUT_PATH=${CMAKE_SOURCE_DIR}/abseil-cpp/lib")
+-if(DEFINED CMAKE_OSX_ARCHITECTURES)
+-    set(ABSEIL_CMAKE_ARGS
+-        ${ABSEIL_CMAKE_ARGS}
+-        "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
+-endif()
+-ExternalProject_Add(abseil-cpp
+-  GIT_REPOSITORY    https://github.com/abseil/abseil-cpp.git
+-  GIT_TAG           ${ABSEIL_VER}
+-  PREFIX            ${CMAKE_SOURCE_DIR}/abseil-cpp
+-  CMAKE_ARGS        ${ABSEIL_CMAKE_ARGS}
++set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)
++find_package(
++  absl
++  REQUIRED
++  COMPONENTS ${ABSEIL_LIBS}
+ )
+-ExternalProject_Get_Property(abseil-cpp install_dir)
+-set(abseil_install_dir ${install_dir})
+-include_directories (${abseil_install_dir}/include)
+-
+ 
+ # Define pybind11 tree module.
+ pybind11_add_module(_tree tree.h tree.cc)
+-add_dependencies(_tree abseil-cpp)
+-
+-if (WIN32 OR MSVC)
+-    set(ABSEIL_LIB_PREF "absl")
+-    set(LIB_SUFF "lib")
+-else()
+-    set(ABSEIL_LIB_PREF "libabsl")
+-    set(LIB_SUFF "a")
+-endif()
+ 
+-# Link abseil static libs.
+-# We don't use find_library here to force cmake to build abseil before linking.
+-set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)
+ foreach(ABSEIL_LIB IN LISTS ABSEIL_LIBS)
+-  target_link_libraries(_tree PRIVATE
+-      "${abseil_install_dir}/lib/python-dm-tree/${ABSEIL_LIB_PREF}_${ABSEIL_LIB}.${LIB_SUFF}")
++  target_link_libraries(_tree PRIVATE "absl::${ABSEIL_LIB}")
+ endforeach()
+ 
+ # Make the module private to tree package.
+ set_target_properties(_tree PROPERTIES OUTPUT_NAME tree/_tree)
+-
+-

--- a/python-dm-tree/PKGBUILD
+++ b/python-dm-tree/PKGBUILD
@@ -12,8 +12,9 @@ makedepends=(python python-build python-installer python-wheel python-setuptools
              cmake git)
 source=("$pkgname-$pkgver.tar.gz::https://pypi.org/packages/source/d/dm-tree/dm-tree-${pkgver}.tar.gz"
         CMakeLists.txt.patch)
+
 sha256sums=('0fcaabbb14e7980377439e7140bd05552739ca5e515ecb3119f234acee4b9430'
-            '84c9cbd52b3852af2e97dc6261c0114c78d40bc3deeb6b7638dd3864df1a9f72')
+            'abd81eb1d12a4dd3e33e599831581ba92a36228bf53d5a23e7ad19d380ef4e38')
 
 _pkgname=dm-tree
 

--- a/python-dm-tree/PKGBUILD
+++ b/python-dm-tree/PKGBUILD
@@ -7,13 +7,24 @@ pkgdesc='tree is a library for working with nested data structures'
 arch=('x86_64')
 url='https://tree.readthedocs.io'
 license=('Apache-2.0')
-depends=(python python-six)
+depends=(python python-six abseil-cpp)
 makedepends=(python python-build python-installer python-wheel python-setuptools
              cmake git)
-source=("$pkgname-$pkgver.tar.gz::https://pypi.org/packages/source/d/dm-tree/dm-tree-${pkgver}.tar.gz")
-sha256sums=('0fcaabbb14e7980377439e7140bd05552739ca5e515ecb3119f234acee4b9430')
+source=("$pkgname-$pkgver.tar.gz::https://pypi.org/packages/source/d/dm-tree/dm-tree-${pkgver}.tar.gz"
+        CMakeLists.txt.patch)
+sha256sums=('0fcaabbb14e7980377439e7140bd05552739ca5e515ecb3119f234acee4b9430'
+            '84c9cbd52b3852af2e97dc6261c0114c78d40bc3deeb6b7638dd3864df1a9f72')
 
 _pkgname=dm-tree
+
+prepare() {
+  cd "${srcdir}/${_pkgname}-${pkgver}"
+  for p in "${source[@]}"; do
+    if [[ ${p} == *.patch ]]; then
+      patch -Np1 -i "${srcdir}/${p}"
+    fi
+  done
+}
 
 build() {
   cd "${srcdir}/${_pkgname}-${pkgver}"


### PR DESCRIPTION
I recreated the patch which fixes `Hunk #3 FAILED at 62.` 

I got `python-dm-tree` to install properly on my system